### PR TITLE
build: :lock: patch lodash vulnerabilities using npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1172,9 +1172,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
       "cloudinary": "^2.9.0"
     },
     "qs": "^6.15.0",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "minimatch": "^10.2.4",
     "handlebars": "^4.7.9",
     "picomatch": "^4.0.4"


### PR DESCRIPTION
Resolved two security vulnerabilities identified in the lodash package 
by updating its resolution via npm overrides:

1. Code Injection via `_.template` (High):
   - Mitigated a vulnerability where `_.template` could allow code injection 
     through imported key names.
     
2. Prototype Pollution in `_.unset` and `_.omit` (Moderate):
   - Patched a prototype pollution flaw caused by an array path bypass.

Changes:
- Bumped 'lodash' version in the "overrides" block.
- Regenerated package-lock.json to enforce the secure version across 
  all transitive dependencies.