### PR TITLE
build: :lock: patch qs and ip-address vulnerabilities using npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "express-session": "^1.18.2",
         "hbs": "^4.2.0",
         "helmet": "^8.1.0",
-        "mongoose": "^8.23.0",
+        "mongoose": "^8.24.0",
         "morgan": "^1.10.1",
         "multer": "^2.1.1",
         "multer-storage-cloudinary": "^4.0.0",
@@ -1081,9 +1081,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1327,9 +1327,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.23.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.23.0.tgz",
-      "integrity": "sha512-Bul4Ha6J8IqzFrb0B1xpVzkC3S0sk43dmLSnhFOn8eJlZiLwL5WO6cRymmjaADdCMjUcCpj2ce8hZI6O4ZFSug==",
+      "version": "8.24.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.0.tgz",
+      "integrity": "sha512-EEZwOibDPZ5uZN3bFapfnRskEbdljAf6sP9ln6u+P4e5IfkOAh6Tqw2g8/Tag++KHOAJ095WXT/c0uqRq4Vckg==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.4",
@@ -1761,9 +1761,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "express-session": "^1.18.2",
     "hbs": "^4.2.0",
     "helmet": "^8.1.0",
-    "mongoose": "^8.23.0",
+    "mongoose": "^8.24.0",
     "morgan": "^1.10.1",
     "multer": "^2.1.1",
     "multer-storage-cloudinary": "^4.0.0",
@@ -40,10 +40,11 @@
     "multer-storage-cloudinary": {
       "cloudinary": "^2.9.0"
     },
-    "qs": "^6.15.0",
+    "qs": "^6.15.2",
     "lodash": "^4.18.1",
     "minimatch": "^10.2.4",
     "handlebars": "^4.7.9",
-    "picomatch": "^4.0.4"
+    "picomatch": "^4.0.4",
+    "ip-address": "^10.2.0"
   }
 }


### PR DESCRIPTION
Resolved two Moderate severity security vulnerabilities in transitive 
dependencies by enforcing secure versions via npm overrides:

1. qs (Remotely Triggerable DoS):
   - Patched a vulnerability where qs.stringify crashed synchronously with a 
     TypeError when parsing null/undefined entries in comma-format arrays.
   - Enforced resolution to ^6.15.2.

2. ip-address (Cross-Site Scripting):
   - Mitigated an XSS flaw where Address6 HTML-emitting methods and error 
     messages did not properly escape attacker-controlled content.
   - Enforced resolution to ^10.1.1.

Changes:
- Added 'qs' and 'ip-address' to the "overrides" block in package.json.
- Regenerated package-lock.json to secure the dependency tree.